### PR TITLE
Use sqlite3 in test and development environments

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: postgresql
+  adapter: sqlite3
   encoding: unicode
   username: jeffreybiles
   password: <%= ENV['DATABASE_PASSWORD'] %>


### PR DESCRIPTION
 In Gemfile sqlite3 is used, so I think here also should use `sqlite3`.